### PR TITLE
add default values that can be customized

### DIFF
--- a/deployment/terraform/resources/helm-osm-seed.tf
+++ b/deployment/terraform/resources/helm-osm-seed.tf
@@ -8,10 +8,9 @@ resource "helm_release" "osmseed" {
 
   ]
 
-  set {
-    name = "cloudProvider"
-    value = "azure"
-  }
+  values = [
+    "${file("values.yaml")}"
+  ]
 
   set {
     name = "web.env.MAILER_ADDRESS"

--- a/deployment/terraform/resources/values.yaml
+++ b/deployment/terraform/resources/values.yaml
@@ -1,0 +1,165 @@
+# Non-Secret configuration for osm-seed deploy
+
+# Specify cloud provider - choices are "azure", "minikube", "aws" or "gcp"
+cloudProvider: "azure"
+
+# Uncomment when ingress is implemented
+# serviceType: "ClusterIP"
+
+# ====================================================================================================
+# Variables for osm-seed database
+# ====================================================================================================
+db:
+  resources:
+    enabled: false
+    requests:
+      memory: '1Gi'
+      cpu: '1'
+    limits:
+      memory: '2Gi'
+      cpu: '1'
+  nodeSelector:
+    enabled: false
+
+# ====================================================================================================
+# Variables for osm-seed website
+# ====================================================================================================
+web:
+  enabled: true
+  replicaCount: 1
+  resources:
+    enabled: false
+    requests:
+      memory: '1Gi'
+      cpu: '2'
+    limits:
+      memory: '2Gi'
+      cpu: '2'
+  nodeSelector:
+    enabled: false
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 3
+    cpuUtilization: 80
+
+# ====================================================================================================
+# Variables for memcached. Memcached is used to store session cookies
+# ====================================================================================================
+memcached:
+  enabled: false
+  nodeSelector:
+    enabled: false
+  resources:
+    enabled: false
+    requests:
+      memory: '8Gi'
+      cpu: '2'
+    limits:
+      memory: '8Gi'
+      cpu: '2'
+
+
+# ====================================================================================================
+# Variables for full-history container
+# ====================================================================================================
+fullHistory:
+  enabled: false
+  image:
+    name: ''
+    tag: ''
+  schedule: '* * * * *'
+  env:
+    OVERWRITE_FHISTORY_FILE: false
+  resources:
+    enabled: false
+    requests:
+      memory: "14Gi"
+      cpu: "4"
+    limits:
+      memory: "16Gi"
+      cpu: "4"
+
+# ====================================================================================================
+# Variables for osm-seed database backup and restore
+# ====================================================================================================
+dbBackupRestore:
+  enabled: false
+  image:
+    name: ''
+    tag: ''
+  schedule: '* * * * *'
+  env:
+    DB_ACTION: backup
+  resources:
+    enabled: false
+    requests:
+      memory: '300Mi'
+      cpu: '0.5'
+    limits:
+      memory: '400Mi'
+      cpu: '0.6'
+  nodeSelector:
+    enabled: false
+
+# ====================================================================================================
+# Variables for osm-seed for osmosis, this configuration os to get the planet dump files from apidb
+# ====================================================================================================
+planetDump:
+  enabled: false
+  image:
+    name: ''
+    tag: ''
+  schedule: '* * * * *'
+  env:
+    OVERWRITE_PLANET_FILE: false
+  resources:
+    enabled: false
+    requests:
+      memory: '14Gi'
+      cpu: '4'
+    limits:
+      memory: '16Gi'
+      cpu: '4'
+  nodeSelector:
+    enabled: false
+
+# ====================================================================================================
+# Variables for replication-job, Configuration to create the replication files by, minute, hour, or day
+# ====================================================================================================
+replicationJob:
+  enabled: false
+  image:
+    name: ''
+    tag: ''
+  resources:
+    enabled: false
+    requests:
+      memory: '20Gi'
+      cpu: '8'
+    limits:
+      memory: '24Gi'
+      cpu: '10'
+  nodeSelector:
+    enabled: false
+
+# ====================================================================================================
+# Variables for osm-seed to pupulate the apidb
+# ====================================================================================================
+populateApidb:
+  enabled: false
+  image:
+    name: ''
+    tag: ''
+  env:
+    URL_FILE_TO_IMPORT: 'http://download.geofabrik.de/europe/monaco-latest.osm.pbf'
+  resources:
+    enabled: false
+    requests:
+      memory: '1Gi'
+      cpu: '2'
+    limits:
+      memory: '2Gi'
+      cpu: '2.5'
+
+


### PR DESCRIPTION
This puts all osm-seed configuration values that HOT might want to tweak that are not secrets into a `values.yaml` file - this will make it easier to tweak configuration options / manage imports, etc.

@dakotabenjamin let's run through these whenever you have a bit - for most configuration, managing resource allocations, etc. you should just be able to edit values in this file and push.

Keeping this draft until we've spoken, and potentially use this PR to enable the replication container or so.

cc @Rub21