### PR TITLE
create replication storage container and provide envvars

### DIFF
--- a/deployment/terraform/resources/helm-osm-seed.tf
+++ b/deployment/terraform/resources/helm-osm-seed.tf
@@ -2,7 +2,7 @@ resource "helm_release" "osmseed" {
   name  = "osmseed-helm"
   repository = "https://devseed.com/osm-seed-chart"
   chart = "osm-seed"
-  version = "1.0.0-dev.h3d60424"
+  version = "1.0.0-dev.h4a425b3"
   wait = false
   depends_on = [
 

--- a/deployment/terraform/resources/helm-osm-seed.tf
+++ b/deployment/terraform/resources/helm-osm-seed.tf
@@ -37,7 +37,6 @@ resource "helm_release" "osmseed" {
     name = "web.env.MAILER_FROM"
     value = var.mailerFrom
   }
-
   set {
     name = "web.env.MAILER_PORT"
     value = var.mailerPort
@@ -58,4 +57,20 @@ resource "helm_release" "osmseed" {
     value = var.osmseed_db_disk_size
   }
 
+  set {
+    name  = "AZURE_STORAGE_CONNECTION_STRING"
+    value = azurerm_storage_account.osmseed.primary_connection_string
+  }
+  set {
+    name  = "AZURE_STORAGE_ACCESS_KEY"
+    value = azurerm_storage_account.osmseed.primary_access_key
+  }
+  set {
+    name  = "AZURE_CONTAINER_NAME"
+    value = "replication"
+  }
+  set {
+    name = "AZURE_STORAGE_ACCOUNT"
+    value = "${local.storage}"
+  }
 }

--- a/deployment/terraform/resources/storage.tf
+++ b/deployment/terraform/resources/storage.tf
@@ -6,4 +6,8 @@ resource "azurerm_storage_account" "osmseed" {
   account_replication_type = "LRS"
 }
 
-#FIXME: storage containers
+resource "azurerm_storage_container" "replication" {
+  name                  = "replication"
+  storage_account_name  = azurerm_storage_account.osmseed.name
+  container_access_type = "private"
+}


### PR DESCRIPTION
Contributes to #8 

cc @batpad @Rub21 

@Rub21 I noticed that we are requiring four envs for [storage account here](https://github.com/developmentseed/osm-seed/blob/develop/osm-seed/templates/jobs/replication-job-deployment.yaml#L59-L66). I don't think that's needed. The only two things necessary would be:
1. AZURE_STORAGE_CONNECTION_STRING
2. AZURE_CONTAINER_NAME

Can you confirm this and make the change on osm-seed? Thank you!