### PR TITLE
Add nodeSelector to populateApiDb values, bump osm-seed version

### DIFF
--- a/deployment/terraform/resources/helm-osm-seed-africa.tf
+++ b/deployment/terraform/resources/helm-osm-seed-africa.tf
@@ -2,7 +2,7 @@ resource "helm_release" "osmseed-africa" {
   name  = "osmseed-helm-africa"
   repository = "https://devseed.com/osm-seed-chart"
   chart = "osm-seed"
-  version = "0.1.0-n687.h1279a34"
+  version = "0.1.0-n688.h58152db"
   wait = false
   depends_on = [
 

--- a/deployment/terraform/resources/values-africa.yaml
+++ b/deployment/terraform/resources/values-africa.yaml
@@ -169,5 +169,7 @@ populateApidb:
     limits:
       memory: '2Gi'
       cpu: '2.5'
+  nodeSelector:
+    enabled: false
 
 

--- a/deployment/terraform/resources/values.yaml
+++ b/deployment/terraform/resources/values.yaml
@@ -169,5 +169,7 @@ populateApidb:
     limits:
       memory: '2Gi'
       cpu: '2.5'
+  nodeSelector:
+    enabled: false
 
 


### PR DESCRIPTION
Two fixes:
   - Seems like `nodeSelector` is a required property for `populateApiDb` and it needs `enabled` to be set to `false`. Ideally, we'd solve that by not making it required, but that just seems slightly tricky and it seems easier to just specify it for now. See https://github.com/helm/helm/issues/8026
   - I had forgotten to `git add` a change to `osm-seed` fixing the `name` field of the letsencrypt-issuer 🤦 - this bumps the osm-seed version to include that change.

@dakotabenjamin lemme know if you're able to attempt a deploy. Thanks!