### PR TITLE
update osm seed version, add dummy values for nodeSelector key, values

### DIFF
--- a/deployment/terraform/resources/values-africa.yaml
+++ b/deployment/terraform/resources/values-africa.yaml
@@ -171,5 +171,6 @@ populateApidb:
       cpu: '2.5'
   nodeSelector:
     enabled: false
-
+    label_key: foo
+    label_value: bar
 

--- a/deployment/terraform/resources/values.yaml
+++ b/deployment/terraform/resources/values.yaml
@@ -171,5 +171,6 @@ populateApidb:
       cpu: '2.5'
   nodeSelector:
     enabled: false
-
+    label_key: foo
+    label_value: bar
 


### PR DESCRIPTION
@dakotabenjamin I finally have reasonable confidence that this will work.

Thanks @Rub21 for the fix here - we maybe able to do this better, but for now, adding dummy values for the `nodeSelector` key / values makes the helm template not break.

@dakotabenjamin would rather do this merge / deploy when you're around. Let me know and we can push the button.
